### PR TITLE
--sample_cat and pbs

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -83,4 +83,25 @@ profiles {
             }
         }
     }
+    pbs {
+        executor {
+            name = 'pbs'
+            cache = 'lenient'
+            time = '48.h'
+        }
+         process{
+            withLabel : 'intenso' {
+                cpus = 8
+                memory = params.kraken_mem
+            }
+            withLabel : 'expresso' {
+                cpus = 6
+                memory = '2G'
+            }
+            withLabel : 'ristretto' {
+                cpus = 1
+                memory = '2G'
+            }
+        }
+    }
 }


### PR DESCRIPTION
Hi Maxime,

just added a flag and process to take CSV input with name, dir of fastqs from the same sample (as you might get from WGS from BGI), and extension of fastqs when paired. 

This works to cat fastq then send to AdapterRemoval.

And added a PBS profile. 

Thanks for the pipeline, saved me writing one!

Bruce